### PR TITLE
Support .toml configuration and DB connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 classroom-seating
+cfg.toml

--- a/README.md
+++ b/README.md
@@ -10,11 +10,17 @@ Classroom seating is a web application empowering teachers to generate classroom
 
 ## Dependencies
 - [Go](https://golang.org/)
+- MySQL / MariaDB
 
 ## Setup
 ```
 go get github.com/Go-Team-Gamma/classroom-seating
 cd $(go env GOPATH)/src/github.com/Go-Team-Gamma/classroom-seating
+cp cfg.toml.example cfg.toml
+```
+Now edit `cfg.toml` appropriately.  
+Finally:
+```
 go build
 ```
 

--- a/cfg.toml.example
+++ b/cfg.toml.example
@@ -1,0 +1,8 @@
+[database]
+host = "127.0.0.1"
+name = "database_name"
+user = "username"
+password = "password"
+
+[http_server]
+port = 9000

--- a/main.go
+++ b/main.go
@@ -2,18 +2,65 @@ package main
 
 import (
 	"fmt"
+	"github.com/BurntSushi/toml"
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/gocraft/dbr"
 	"html"
+	"io/ioutil"
 	"log"
 	"net/http"
 )
 
 func main() {
+	var (
+		cfg Config
+	)
+
+	dat, err := ioutil.ReadFile("cfg.toml")
+	if err != nil {
+		log.Fatal(err)
+	}
+	strDat := string(dat)
+
+	if _, err := toml.Decode(strDat, &cfg); err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("%+v\n", cfg)
+
+	dbString := fmt.Sprintf("%v:%v@/%v", cfg.Database.User, cfg.Database.Password, cfg.Database.Name)
+	conn, err := dbr.Open("mysql", dbString, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	sess := conn.NewSession(nil)
+	tx, err := sess.Begin()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer tx.RollbackUnlessCommitted()
+
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "Hello %q", html.EscapeString(r.URL.Path))
 	})
 
-	err := http.ListenAndServe(":9000", nil)
+	err = http.ListenAndServe(fmt.Sprintf(":%v", cfg.Server.Port), nil)
 	if err != nil {
 		log.Fatal("http.listenAndServe: ", err)
 	}
+}
+
+type Config struct {
+	Database DatabaseConfig   `toml:"database"`
+	Server   HttpServerConfig `toml:"http_server"`
+}
+
+type DatabaseConfig struct {
+	Host     string
+	Name     string
+	User     string
+	Password string
+}
+
+type HttpServerConfig struct {
+	Port uint
 }


### PR DESCRIPTION
- Uses Toml as the configuration file format.
- Moves the HTTP server port into the configuration file.
- Connects to MySQL via database section in cfg.toml.